### PR TITLE
DEV-2930 added response body in failed request error

### DIFF
--- a/src/internal/api/http.go
+++ b/src/internal/api/http.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -371,7 +372,14 @@ func (c *httpClient) performRequest(req *http.Request, wantResponseCode int) (*h
 	}
 
 	if resp.StatusCode != wantResponseCode {
-		return resp, errors.Errorf("expected response code to be %d, but got %d instead", wantResponseCode, resp.StatusCode)
+		var response string
+		if data, err := io.ReadAll(resp.Body); err != nil {
+			response = fmt.Sprintf("unable to read response body: %v", err)
+		} else {
+			response = string(data)
+		}
+
+		return resp, errors.Errorf("expected response code to be %d, but got %d instead. %s", wantResponseCode, resp.StatusCode, response)
 	}
 
 	return resp, nil

--- a/src/internal/app/app.go
+++ b/src/internal/app/app.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"fmt"
+
 	"github.com/futurehomeno/cliffhanger/adapter"
 	cliffApp "github.com/futurehomeno/cliffhanger/app"
 	"github.com/futurehomeno/cliffhanger/lifecycle"
@@ -93,7 +95,7 @@ func (a *application) Login(credentials *cliffApp.LoginCredentials) error {
 		a.lifecycle.SetAuthState(lifecycle.AuthStateNotAuthenticated)
 		a.lifecycle.SetConfigState(lifecycle.ConfigStateNotConfigured)
 
-		return errors.Wrap(err, "failed to login")
+		return errors.Wrap(err, fmt.Sprintf("failed to login as '%s'", credentials.Username))
 	}
 
 	if err := a.registerChargers(); err != nil {


### PR DESCRIPTION
One of the clients receive `400` when he/she tries to login.
Unfortunately Easee API return 400 in almost every bad scenario (including invalid credentials) and the body contains the actual info of what went wrong.